### PR TITLE
chore: add debug points in math helpers

### DIFF
--- a/src/components/tools/crosshairs/CrosshairSVG2D.vue
+++ b/src/components/tools/crosshairs/CrosshairSVG2D.vue
@@ -83,6 +83,7 @@ export default defineComponent({
             x: point2D[0],
             y: point2D[1],
           };
+          console.log('MPR 画线', position2D.value);
         }
       }
     };

--- a/src/components/tools/crosshairs/CrosshairsWidget2D.vue
+++ b/src/components/tools/crosshairs/CrosshairsWidget2D.vue
@@ -48,6 +48,7 @@ export default defineComponent({
     const widget = view.widgetManager.addWidget(
       factory
     ) as vtkCrosshairsViewWidget;
+    console.log('MPR 初始化: 添加视图组件');
 
     onUnmounted(() => {
       view.widgetManager.removeWidget(factory);

--- a/src/store/tools/crosshairs.ts
+++ b/src/store/tools/crosshairs.ts
@@ -53,6 +53,7 @@ export const useCrosshairsToolStore = defineStore('crosshairs', () => {
 
   function setPosition(pos: Vector3) {
     position.value = pos;
+    console.log('MPR 设置位置', pos);
   }
 
   // update the slicing
@@ -95,11 +96,13 @@ export const useCrosshairsToolStore = defineStore('crosshairs', () => {
     const origin = handle.getOrigin();
     if (origin) {
       position.value = origin;
+      console.log('MPR 位置修改', origin);
     }
   });
 
   function activateTool() {
     active.value = true;
+    console.log('MPR 初始化');
     return true;
   }
 

--- a/src/utils/vtk-helpers.ts
+++ b/src/utils/vtk-helpers.ts
@@ -82,9 +82,11 @@ export function intersectMouseEventWithPlane(
  */
 export function worldToSVG(xyz: Vector3, renderer: vtkRenderer) {
   const coords = computeWorldToDisplay(xyz, renderer);
+  debugger;
   const view = renderer.getRenderWindow()?.getViews()?.[0];
   if (coords && view) {
     const [, height] = view.getViewportSize(renderer);
+    debugger;
     // convert from canvas space to svg space
     return [
       coords[0] / devicePixelRatio,
@@ -131,9 +133,13 @@ export function getShiftedOpacityFromPreset(
       points.push([OpacityPoints[i], OpacityPoints[i + 1]]);
     }
 
+    debugger;
     const [xmin, xmax] = effectiveRange;
+    debugger;
     const width = xmax - xmin;
+    debugger;
     return points.map(([x, y]) => {
+      debugger;
       // Non-zero values should be affected by shift
       // but preset values of zero should not
       const shifted = y && y - shiftAlpha;


### PR DESCRIPTION
## Summary
- add `debugger` breakpoints to inspect world-to-SVG coordinate conversion
- add debug breakpoints around preset opacity shifting math

## Testing
- `npm test` *(fails: connect ENETUNREACH 50.58.123.189:443)*

------
https://chatgpt.com/codex/tasks/task_e_68998f056978833399a23b21d9635d77